### PR TITLE
Enable approve/merge bot

### DIFF
--- a/build-config.yaml
+++ b/build-config.yaml
@@ -1,1 +1,3 @@
 requiredCoverage: 82
+approveBotEnabled: true
+mergeBotEnabled: true


### PR DESCRIPTION
### Semver:
`NONE`: `build-config.yaml` only.

### Reason for change:
`approveBotEnabled` / `mergeBotEnabled` were unset, so the `automerge`
workflow ran but skipped its approve + merge steps (both gated on these
flags). Result: repo-file-sync / dependabot PRs that pass all checks sit
`BLOCKED` on the rulesets required approval, never merging.

Enabling both opts the repo into auto approve + merge, matching the 52
sibling repos that already set them.

### How to test:
n/a — config flags read by `automerge.yml`.
